### PR TITLE
Fix chrome data dir clone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
       env:
         CI: true
     - name: Publish Test Coverage
+      if: github.event_name == 'pull_request'
       uses: romeovs/lcov-reporter-action@v0.2.16
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/etc/core.api.json
+++ b/etc/core.api.json
@@ -35,43 +35,12 @@
               "excerptTokens": [
                 {
                   "kind": "Content",
-                  "text": "constructor(domainPathRouter: "
+                  "text": "constructor(config: "
                 },
                 {
                   "kind": "Reference",
-                  "text": "DomainPathRouter",
-                  "canonicalReference": "@authless/core!DomainPathRouter:class"
-                },
-                {
-                  "kind": "Content",
-                  "text": ", botRouter: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "BotRouter",
-                  "canonicalReference": "@authless/core!BotRouter:class"
-                },
-                {
-                  "kind": "Content",
-                  "text": ", puppeteerParams: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "PuppeteerParams",
-                  "canonicalReference": "@authless/core!PuppeteerParams:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": ", puppeteerPlugins?: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "PuppeteerExtraPlugin",
-                  "canonicalReference": "puppeteer-extra!PuppeteerExtraPlugin:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": "[]"
+                  "text": "IServerConfig",
+                  "canonicalReference": "@authless/core!~IServerConfig:interface"
                 },
                 {
                   "kind": "Content",
@@ -82,31 +51,10 @@
               "overloadIndex": 1,
               "parameters": [
                 {
-                  "parameterName": "domainPathRouter",
+                  "parameterName": "config",
                   "parameterTypeTokenRange": {
                     "startIndex": 1,
                     "endIndex": 2
-                  }
-                },
-                {
-                  "parameterName": "botRouter",
-                  "parameterTypeTokenRange": {
-                    "startIndex": 3,
-                    "endIndex": 4
-                  }
-                },
-                {
-                  "parameterName": "puppeteerParams",
-                  "parameterTypeTokenRange": {
-                    "startIndex": 5,
-                    "endIndex": 6
-                  }
-                },
-                {
-                  "parameterName": "puppeteerPlugins",
-                  "parameterTypeTokenRange": {
-                    "startIndex": 7,
-                    "endIndex": 9
                   }
                 }
               ]
@@ -276,6 +224,33 @@
               ],
               "releaseTag": "Beta",
               "name": "logger",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "@authless/core!AuthlessServer#proxy:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "proxy?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "ProxyConfig",
+                  "canonicalReference": "@authless/core!ProxyConfig:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "releaseTag": "Beta",
+              "name": "proxy",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
@@ -1088,7 +1063,7 @@
                 {
                   "kind": "Reference",
                   "text": "ProxyConfig",
-                  "canonicalReference": "@authless/core!~ProxyConfig:interface"
+                  "canonicalReference": "@authless/core!ProxyConfig:interface"
                 },
                 {
                   "kind": "Content",
@@ -2525,6 +2500,97 @@
               ],
               "releaseTag": "Beta",
               "name": "url",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ],
+          "extendsTokenRanges": []
+        },
+        {
+          "kind": "Interface",
+          "canonicalReference": "@authless/core!ProxyConfig:interface",
+          "docComment": "/**\n * Options to add a proxy to Puppeteer connections\n *\n * @beta\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export interface ProxyConfig "
+            }
+          ],
+          "releaseTag": "Beta",
+          "name": "ProxyConfig",
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@authless/core!ProxyConfig#address:member",
+              "docComment": "/**\n * The IP address of the proxy\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "address: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "releaseTag": "Beta",
+              "name": "address",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@authless/core!ProxyConfig#credentials:member",
+              "docComment": "/**\n * The user credentials to connect to the proxy\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "credentials: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "{\n        username: string;\n        password: string;\n    }"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "releaseTag": "Beta",
+              "name": "credentials",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@authless/core!ProxyConfig#port:member",
+              "docComment": "/**\n * The port number of the proxy\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "port: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "number"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "releaseTag": "Beta",
+              "name": "port",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2

--- a/etc/core.api.md
+++ b/etc/core.api.md
@@ -35,7 +35,8 @@ export class AuthlessClient {
 
 // @beta
 export class AuthlessServer {
-    constructor(domainPathRouter: DomainPathRouter, botRouter: BotRouter, puppeteerParams: PuppeteerParams, puppeteerPlugins?: PuppeteerExtraPlugin[]);
+    // Warning: (ae-forgotten-export) The symbol "IServerConfig" needs to be exported by the entry point index.d.ts
+    constructor(config: IServerConfig);
     // (undocumented)
     botRouter: BotRouter;
     // (undocumented)
@@ -44,6 +45,8 @@ export class AuthlessServer {
     static launchBrowser(domainPath: DomainPath, bot: Bot, config?: BrowserConfig): Promise<Browser>;
     // (undocumented)
     logger: any;
+    // (undocumented)
+    proxy?: ProxyConfig;
     // (undocumented)
     puppeteerParams?: PuppeteerParams;
     // (undocumented)
@@ -93,7 +96,6 @@ export interface BrowserConfig {
     adBlockerConfig?: {
         blockTrackers: boolean;
     };
-    // Warning: (ae-forgotten-export) The symbol "ProxyConfig" needs to be exported by the entry point index.d.ts
     proxy?: ProxyConfig;
     puppeteerParams?: PuppeteerParams;
     puppeteerPlugins?: PuppeteerExtraPlugin[];
@@ -219,6 +221,16 @@ export interface IResponseResponse {
     text: string;
     // (undocumented)
     url: string;
+}
+
+// @beta
+export interface ProxyConfig {
+    address: string;
+    credentials: {
+        username: string;
+        password: string;
+    };
+    port: number;
 }
 
 // Warning: (ae-forgotten-export) The symbol "InterceptOptions" needs to be exported by the entry point index.d.ts

--- a/etc/tmp/core.api.md
+++ b/etc/tmp/core.api.md
@@ -35,7 +35,8 @@ export class AuthlessClient {
 
 // @beta
 export class AuthlessServer {
-    constructor(domainPathRouter: DomainPathRouter, botRouter: BotRouter, puppeteerParams: PuppeteerParams, puppeteerPlugins?: PuppeteerExtraPlugin[]);
+    // Warning: (ae-forgotten-export) The symbol "IServerConfig" needs to be exported by the entry point index.d.ts
+    constructor(config: IServerConfig);
     // (undocumented)
     botRouter: BotRouter;
     // (undocumented)
@@ -44,6 +45,8 @@ export class AuthlessServer {
     static launchBrowser(domainPath: DomainPath, bot: Bot, config?: BrowserConfig): Promise<Browser>;
     // (undocumented)
     logger: any;
+    // (undocumented)
+    proxy?: ProxyConfig;
     // (undocumented)
     puppeteerParams?: PuppeteerParams;
     // (undocumented)
@@ -93,7 +96,6 @@ export interface BrowserConfig {
     adBlockerConfig?: {
         blockTrackers: boolean;
     };
-    // Warning: (ae-forgotten-export) The symbol "ProxyConfig" needs to be exported by the entry point index.d.ts
     proxy?: ProxyConfig;
     puppeteerParams?: PuppeteerParams;
     puppeteerPlugins?: PuppeteerExtraPlugin[];
@@ -219,6 +221,16 @@ export interface IResponseResponse {
     text: string;
     // (undocumented)
     url: string;
+}
+
+// @beta
+export interface ProxyConfig {
+    address: string;
+    credentials: {
+        username: string;
+        password: string;
+    };
+    port: number;
 }
 
 // Warning: (ae-forgotten-export) The symbol "InterceptOptions" needs to be exported by the entry point index.d.ts

--- a/src/bots/bot.ts
+++ b/src/bots/bot.ts
@@ -197,10 +197,7 @@ export class Bot {
     if(this.rateLimit === 0) {
       return true
     }
-    if(this.getUsage() < this.rateLimit) {
-      return true
-    }
-    return false
+    return this.getUsage() < this.rateLimit
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ export {
   ICache,
   URLParams,
   PuppeteerParams,
+  ProxyConfig,
   BrowserConfig,
   BotConfig,
   Xhr,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,12 +1,20 @@
 import * as path from 'path'
 import { AnonBot, Bot, BotRouter, DomainPath, DomainPathRouter } from '../index'
-import { BrowserConfig, PuppeteerParams, URLParams } from '../types'
+import { BrowserConfig, ProxyConfig, PuppeteerParams, URLParams } from '../types'
 import express, { Request as ExpressRequest, Response as ExpressResponse } from 'express'
 import puppeteer, { PuppeteerExtraPlugin } from 'puppeteer-extra'
 // import AdblockerPlugin from 'puppeteer-extra-plugin-adblocker'
 import { Browser } from 'puppeteer'
 import ProxyPlugin from 'puppeteer-extra-plugin-proxy'
 import StealthPlugin from 'puppeteer-extra-plugin-stealth'
+
+interface IServerConfig {
+  domainPathRouter: DomainPathRouter
+  botRouter: BotRouter
+  puppeteerParams: PuppeteerParams
+  puppeteerPlugins?: PuppeteerExtraPlugin[]
+  proxy?: ProxyConfig
+}
 
 /**
  * Helper class to start your running Authless server
@@ -29,6 +37,7 @@ export class AuthlessServer {
   logger: any
   puppeteerParams?: PuppeteerParams
   puppeteerPlugins?: PuppeteerExtraPlugin[]
+  proxy?: ProxyConfig
   domainPathRouter: DomainPathRouter
   botRouter: BotRouter
   responses: any[]
@@ -39,11 +48,12 @@ export class AuthlessServer {
    * @beta
    */
   // eslint-disable-next-line max-params
-  constructor (domainPathRouter: DomainPathRouter, botRouter: BotRouter, puppeteerParams: PuppeteerParams, puppeteerPlugins?: PuppeteerExtraPlugin[]) {
-    this.domainPathRouter = domainPathRouter
-    this.botRouter = botRouter
-    this.puppeteerParams = puppeteerParams
-    this.puppeteerPlugins = puppeteerPlugins
+  constructor (config: IServerConfig) {
+    this.domainPathRouter = config.domainPathRouter
+    this.botRouter = config.botRouter
+    this.puppeteerParams = config.puppeteerParams
+    this.puppeteerPlugins = config.puppeteerPlugins
+    this.proxy = config.proxy
     this.responses = []
     this.logger = {
       log: (data) => console.log(data)
@@ -151,7 +161,8 @@ export class AuthlessServer {
 
     // initialise the browser
     const browser = await AuthlessServer.launchBrowser(selectedDomainPath, selectedBot, {
-      puppeteerParams: this.puppeteerParams
+      puppeteerParams: this.puppeteerParams,
+      proxy: this.proxy
     })
     const page = await browser.newPage()
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -77,6 +77,7 @@ export class AuthlessServer {
       userDataDir = path.resolve(
         path.join(process.env.CHROME_USER_DATA_DIR, dataDirName))
     }
+    userDataDir = `${userDataDir}-${domainPath.domain}-${bot.username ?? 'anon'}`
     const browser = await puppeteer.launch({
       ...puppeteerParams,
       ...bot.browserConfig,

--- a/src/types.ts
+++ b/src/types.ts
@@ -180,7 +180,7 @@ export interface IResponse {
  *
  * @beta
  */
-interface ProxyConfig {
+export interface ProxyConfig {
 
   /**
    * The IP address of the proxy


### PR DESCRIPTION
## Proposed changes

Fixes a bug where different chrome-data-dirs were not getting created for different users/service types.
Also makes sure proxy is applied when called from AuthlessServer constructor

## Types of changes

What types of changes does your code introduce?
_Remove the bullet points that don't fit_

- Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. This is simply a reminder of what reviewers are always looking for before merging code._

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
